### PR TITLE
Add health and temp support to Settings

### DIFF
--- a/application/qml/pages/MainPage.qml
+++ b/application/qml/pages/MainPage.qml
@@ -177,9 +177,7 @@ Page {
                     }
                     MyDetailItem {
                         label: qsTr("Temperature:")
-                        // TODO: use weird degrees for US users
-                        //value: useImperial ? celsiusToFahrenheit(battery.temperature) + " F" : Math.floor(battery.temperature / 10) + " °C"
-                        value: Math.floor(battery.temperature / 10) + " °C"
+                        value: (Qt.locale().measurementSystem == Locale.ImperialUSSystem) ? Math.floor((battery.temperature / 10) * 1.8 + 32) + " F" : Math.floor(battery.temperature / 10) + " °C"
                     }
                 }
             }

--- a/application/qml/pages/SettingsPage.qml
+++ b/application/qml/pages/SettingsPage.qml
@@ -43,9 +43,11 @@ Page {
             highLimitSlider.value = settings.highLimit
             lowLimitSlider.value = settings.lowLimit
             highAlertSlider.value = settings.highAlert
+            healthAlertSlider.value = settings.healthAlert
             lowAlertSlider.value = settings.lowAlert
             highIntervalSlider.value = settings.highNotificationsInterval
             lowIntervalSlider.value = settings.lowNotificationsInterval
+            healthIntervalSlider.value = settings.healthNotificationsInterval
             if(logger.debug) logger.log("SettingsPage values updated")
             daemonCheck.start()
         }
@@ -362,6 +364,59 @@ Page {
 
                 AdjustmentButtons {
                     targetSlider: lowIntervalSlider
+                    smallChange: 10
+                    largeChange: 60
+                }
+
+                SectionHeader { text: qsTr("Battery health notification") }
+
+                MySlider {
+                    id: healthAlertSlider
+                    minimumValue: 0
+                    maximumValue: 2
+                    stepSize: 1
+                    onValueChanged: {
+                        if(healthAlertSlider.value <= value)
+                            healthAlertSlider.value = value + 1
+                    }
+                    valueText: {
+                      if (value === 0)
+                        return "None"
+                      if (value === 1)
+                        return "Warning"
+                      if (value === 2)
+                        return "Critical"
+                    }
+                    onReleased: save()
+                    function save(){
+                        settings.healthAlert = value
+                    }
+                }
+
+                SectionHeader { text: qsTr("Battery health warning interval") }
+
+                MySlider {
+                    id: healthIntervalSlider
+                    minimumValue: 50
+                    maximumValue: 610
+                    stepSize: 10
+                    valueText: updateValueText()
+                    onValueChanged: updateValueText()
+                    function updateValueText() {
+                        if(value == 50)
+                            return qsTr("Once")
+                        if(value == 610)
+                            return qsTr("Never")
+                        return Math.floor(value / 60) + (value % 60 < 10 ? ":0" + value % 60 : ":" + value % 60)
+                    }
+                    onReleased: save()
+                    function save() {
+                        settings.healthNotificationsInterval = value
+                    }
+                }
+
+                AdjustmentButtons {
+                    targetSlider: healthIntervalSlider
                     smallChange: 10
                     largeChange: 60
                 }

--- a/application/qml/pages/SettingsPage.qml
+++ b/application/qml/pages/SettingsPage.qml
@@ -374,7 +374,7 @@ Page {
                     color: Theme.highlightColor
                 }
                 Label {
-                    text: qsTr("Display visual and audible notifications about battery health, when the battery temperature is below or above safe values.")
+                    text: qsTr("Display visual and audible notifications about battery health, when the battery status exceeds safe values.<br />This usually means high temperature but can be affected by other factors depending on the hardware.")
                     anchors {
                         left: parent.left
                         right: parent.right
@@ -386,15 +386,15 @@ Page {
                     wrapMode: Text.Wrap
                 }
 
-                SectionHeader { text: qsTr("Battery health notification") }
+                SectionHeader { text: qsTr("Health notification") }
 
                 ComboBox {
                     id: healthSelector
                     width: parent.width
-                    label: qsTr("Warn on Health status" + ":")
+                    label: qsTr("Notify on Health status" + ":")
                     currentIndex: settings.healthAlert
                     menu: ContextMenu {
-                        MenuItem { text: qsTr("None") }
+                        MenuItem { text: qsTr("Never") }
                         MenuItem { text: qsTr("Warning") }
                         MenuItem { text: qsTr("Critical") }
                     }
@@ -404,7 +404,7 @@ Page {
                     }
                 }
 
-                SectionHeader { text: qsTr("Battery health warning interval") }
+                SectionHeader { text: qsTr("Health notification interval") }
 
                 MySlider {
                     id: healthIntervalSlider

--- a/application/qml/pages/SettingsPage.qml
+++ b/application/qml/pages/SettingsPage.qml
@@ -43,7 +43,7 @@ Page {
             highLimitSlider.value = settings.highLimit
             lowLimitSlider.value = settings.lowLimit
             highAlertSlider.value = settings.highAlert
-            healthAlertSlider.value = settings.healthAlert
+            healthSelector.currentIndex = settings.healthAlert
             lowAlertSlider.value = settings.lowAlert
             highIntervalSlider.value = settings.highNotificationsInterval
             lowIntervalSlider.value = settings.lowNotificationsInterval
@@ -368,28 +368,39 @@ Page {
                     largeChange: 60
                 }
 
+                Label {
+                    x: Theme.paddingLarge
+                    text: qsTr("Health Notification settings")
+                    color: Theme.highlightColor
+                }
+                Label {
+                    text: qsTr("Display visual and audible notifications about battery health, when the battery temperature is below or above safe values.")
+                    anchors {
+                        left: parent.left
+                        right: parent.right
+                        leftMargin: Theme.horizontalPageMargin*2
+                        rightMargin: Theme.horizontalPageMargin
+                    }
+                    color: Theme.primaryColor
+                    font.pixelSize: Theme.fontSizeExtraSmall
+                    wrapMode: Text.Wrap
+                }
+
                 SectionHeader { text: qsTr("Battery health notification") }
 
-                MySlider {
-                    id: healthAlertSlider
-                    minimumValue: 0
-                    maximumValue: 2
-                    stepSize: 1
-                    onValueChanged: {
-                        if(healthAlertSlider.value <= value)
-                            healthAlertSlider.value = value + 1
+                ComboBox {
+                    id: healthSelector
+                    width: parent.width
+                    label: qsTr("Warn on Health status" + ":")
+                    currentIndex: settings.healthAlert
+                    menu: ContextMenu {
+                        MenuItem { text: qsTr("None") }
+                        MenuItem { text: qsTr("Warning") }
+                        MenuItem { text: qsTr("Critical") }
                     }
-                    valueText: {
-                      if (value === 0)
-                        return "None"
-                      if (value === 1)
-                        return "Warning"
-                      if (value === 2)
-                        return "Critical"
-                    }
-                    onReleased: save()
-                    function save(){
-                        settings.healthAlert = value
+                    onValueChanged: save()
+                    function save() {
+                        settings.healthAlert = healthSelector.currentIndex
                     }
                 }
 

--- a/application/src/settings.cpp
+++ b/application/src/settings.cpp
@@ -31,8 +31,10 @@ Settings::Settings(Logger *newLogger, QObject *parent) : QObject(parent)
     // Read in the values
     loadInteger(sLowAlert, lowAlert, 5, 99);
     loadInteger(sHighAlert, highAlert, 6, 100);
+    loadInteger(sHealthAlert, healthAlert, 0, 2);
     loadInteger(sHighNotificationsInterval, highNotificationsInterval, 50, 610);
     loadInteger(sLowNotificationsInterval, lowNotificationsInterval, 50, 610);
+    loadInteger(sHealthNotificationsInterval, healthNotificationsInterval, 50, 610);
     loadInteger(sLimitEnabled, limitEnabled, 0, 1);
     loadInteger(sLowLimit, lowLimit, 5, 99);
     loadInteger(sHighLimit, highLimit, 6, 100);
@@ -43,10 +45,12 @@ Settings::Settings(Logger *newLogger, QObject *parent) : QObject(parent)
     loadString(sNotificationTitle, notificationTitle);
     loadString(sNotificationLowText, notificationLowText);
     loadString(sNotificationHighText, notificationHighText);
+    loadString(sNotificationHealthText, notificationHealthText);
 
     saveString(sNotificationTitle, tr("Battery charge %1%"), notificationTitle);
     saveString(sNotificationLowText, tr("Please connect the charger."), notificationLowText);
     saveString(sNotificationHighText, tr("Please disconnect the charger."), notificationHighText);
+    saveString(sNotificationHealthText, tr("Battery health"), notificationHealthText);
 }
 
 Settings::~Settings()
@@ -105,6 +109,12 @@ void Settings::setLowNotificationsInterval(const int newInterval) {
     }
 }
 
+void Settings::setHealthNotificationsInterval(const int newInterval) {
+    if(saveInteger(sHealthNotificationsInterval, newInterval, healthNotificationsInterval)) {
+        emit healthNotificationsIntervalChanged(healthNotificationsInterval);
+    }
+}
+
 void Settings::setLowLimit(const int newLimit) {
     if(saveInteger(sLowLimit, newLimit, lowLimit)) {
         emit lowLimitChanged(lowLimit);
@@ -134,6 +144,11 @@ void Settings::setNotificationLowText(const QString newText) {
 void Settings::setNotificationHighText(const QString newText) {
     if(saveString(sNotificationHighText, newText, notificationHighText))
         emit notificationHighTextChanged(notificationHighText);
+}
+
+void Settings::setNotificationHealthText(const QString newText) {
+    if(saveString(sNotificationHealthText, newText, notificationHealthText))
+        emit notificationHealthTextChanged(notificationHealthText);
 }
 
 void Settings::setLogLevel(const int newLogLevel) {

--- a/application/src/settings.cpp
+++ b/application/src/settings.cpp
@@ -45,12 +45,16 @@ Settings::Settings(Logger *newLogger, QObject *parent) : QObject(parent)
     loadString(sNotificationTitle, notificationTitle);
     loadString(sNotificationLowText, notificationLowText);
     loadString(sNotificationHighText, notificationHighText);
-    loadString(sNotificationHealthText, notificationHealthText);
+    loadString(sNotificationHealthTitle, notificationHealthTitle);
+    loadString(sNotificationHealthWarnText, notificationHealthWarnText);
+    loadString(sNotificationHealthCritText, notificationHealthCritText);
 
     saveString(sNotificationTitle, tr("Battery charge %1%"), notificationTitle);
     saveString(sNotificationLowText, tr("Please connect the charger."), notificationLowText);
     saveString(sNotificationHighText, tr("Please disconnect the charger."), notificationHighText);
-    saveString(sNotificationHealthText, tr("Battery health"), notificationHealthText);
+    saveString(sNotificationHealthTitle, tr("Battery health %1"), notificationHealthTitle);
+    saveString(sNotificationHealthWarnText, tr("Battery health is not good"), notificationHealthWarnText);
+    saveString(sNotificationHealthCritText, tr("Battery health is critical"), notificationHealthCritText);
 }
 
 Settings::~Settings()
@@ -76,7 +80,9 @@ QString Settings::getLogFilename()                 { return logFilename; }
 QString Settings::getNotificationTitle()           { return notificationTitle; }
 QString Settings::getNotificationLowText()         { return notificationLowText; }
 QString Settings::getNotificationHighText()        { return notificationHighText; }
-QString Settings::getNotificationHealthText()      { return notificationHealthText; }
+QString Settings::getNotificationHealthTitle()         { return notificationHealthTitle; }
+QString Settings::getNotificationHealthWarnText()      { return notificationHealthWarnText; }
+QString Settings::getNotificationHealthCritText()      { return notificationHealthCritText; }
 int     Settings::getLogLevel()                    { return logLevel; }
 
 void Settings::setLowAlert(const int newLimit) {
@@ -146,9 +152,19 @@ void Settings::setNotificationHighText(const QString newText) {
         emit notificationHighTextChanged(notificationHighText);
 }
 
-void Settings::setNotificationHealthText(const QString newText) {
-    if(saveString(sNotificationHealthText, newText, notificationHealthText))
-        emit notificationHealthTextChanged(notificationHealthText);
+void Settings::setNotificationHealthTitle(const QString newText) {
+    if(saveString(sNotificationHealthTitle, newText, notificationTitle))
+        emit notificationHealthTitleChanged(notificationTitle);
+}
+
+void Settings::setNotificationHealthWarnText(const QString newText) {
+    if(saveString(sNotificationHealthWarnText, newText, notificationHealthWarnText))
+        emit notificationHealthWarnTextChanged(notificationHealthWarnText);
+}
+
+void Settings::setNotificationHealthCritText(const QString newText) {
+    if(saveString(sNotificationHealthCritText, newText, notificationHealthCritText))
+        emit notificationHealthCritTextChanged(notificationHealthCritText);
 }
 
 void Settings::setLogLevel(const int newLogLevel) {

--- a/application/src/settings.cpp
+++ b/application/src/settings.cpp
@@ -56,20 +56,24 @@ Settings::~Settings()
 }
 
 // Getters condensed.
-int     Settings::getLowAlert()                  { return lowAlert; }
-int     Settings::getHighAlert()                 { return highAlert; }
-int     Settings::getHighNotificationsInterval() { return highNotificationsInterval; }
-int     Settings::getLowNotificationsInterval()  { return lowNotificationsInterval; }
-int     Settings::getLowLimit()                  { return lowLimit; }
-int     Settings::getHighLimit()                 { return highLimit; }
-bool    Settings::getLimitEnabled()              { return limitEnabled == 1; }
-QString Settings::getLowAlertFile()              { return lowAlertFile; }
-QString Settings::getHighAlertFile()             { return highAlertFile; }
-QString Settings::getLogFilename()               { return logFilename; }
-QString Settings::getNotificationTitle()         { return notificationTitle; }
-QString Settings::getNotificationLowText()       { return notificationLowText; }
-QString Settings::getNotificationHighText()      { return notificationHighText; }
-int     Settings::getLogLevel()                  { return logLevel; }
+int     Settings::getLowAlert()                    { return lowAlert; }
+int     Settings::getHighAlert()                   { return highAlert; }
+int     Settings::getHealthAlert()                 { return healthAlert; }
+int     Settings::getHighNotificationsInterval()   { return highNotificationsInterval; }
+int     Settings::getLowNotificationsInterval()    { return lowNotificationsInterval; }
+int     Settings::getHealthNotificationsInterval() { return healthNotificationsInterval; }
+int     Settings::getLowLimit()                    { return lowLimit; }
+int     Settings::getHighLimit()                   { return highLimit; }
+bool    Settings::getLimitEnabled()                { return limitEnabled == 1; }
+QString Settings::getLowAlertFile()                { return lowAlertFile; }
+QString Settings::getHighAlertFile()               { return highAlertFile; }
+QString Settings::getHealthAlertFile()             { return healthAlertFile; }
+QString Settings::getLogFilename()                 { return logFilename; }
+QString Settings::getNotificationTitle()           { return notificationTitle; }
+QString Settings::getNotificationLowText()         { return notificationLowText; }
+QString Settings::getNotificationHighText()        { return notificationHighText; }
+QString Settings::getNotificationHealthText()      { return notificationHealthText; }
+int     Settings::getLogLevel()                    { return logLevel; }
 
 void Settings::setLowAlert(const int newLimit) {
     if(saveInteger(sLowAlert, newLimit, lowAlert)) {
@@ -80,6 +84,12 @@ void Settings::setLowAlert(const int newLimit) {
 void Settings::setHighAlert(const int newLimit) {
     if(saveInteger(sHighAlert, newLimit, highAlert)) {
         emit highAlertChanged(highAlert);
+    }
+}
+
+void Settings::setHealthAlert(const int newLimit) {
+    if(saveInteger(sHealthAlert, newLimit, healthAlert)) {
+        emit healthAlertChanged(healthAlert);
     }
 }
 

--- a/application/src/settings.h
+++ b/application/src/settings.h
@@ -27,16 +27,20 @@ class Settings : public QObject
     Q_OBJECT
     Q_PROPERTY(int highAlert READ getHighAlert WRITE setHighAlert NOTIFY highAlertChanged)
     Q_PROPERTY(int lowAlert READ getLowAlert WRITE setLowAlert NOTIFY lowAlertChanged)
+    Q_PROPERTY(int healthAlert READ getHealthAlert WRITE setHealthAlert NOTIFY healthAlertChanged)
     Q_PROPERTY(int highNotificationsInterval READ getHighNotificationsInterval WRITE setHighNotificationsInterval NOTIFY highNotificationsIntervalChanged)
     Q_PROPERTY(int lowNotificationsInterval READ getLowNotificationsInterval WRITE setLowNotificationsInterval NOTIFY lowNotificationsIntervalChanged)
+    Q_PROPERTY(int healthNotificationsInterval READ getHealthNotificationsInterval WRITE setHealthNotificationsInterval NOTIFY healthNotificationsIntervalChanged)
     Q_PROPERTY(int highLimit READ getHighLimit WRITE setHighLimit NOTIFY highLimitChanged)
     Q_PROPERTY(int lowLimit READ getLowLimit WRITE setLowLimit NOTIFY lowLimitChanged)
     Q_PROPERTY(bool limitEnabled READ getLimitEnabled WRITE setLimitEnabled NOTIFY limitEnabledChanged)
     Q_PROPERTY(QString highAlertFile READ getHighAlertFile NOTIFY highAlertFileChanged)
     Q_PROPERTY(QString lowAlertFile READ getLowAlertFile NOTIFY lowAlertFileChanged)
+    Q_PROPERTY(QString healthAlertFile READ getHealthAlertFile NOTIFY healthAlertFileChanged)
     Q_PROPERTY(QString notificationTitle READ getNotificationTitle WRITE setNotificationTitle NOTIFY notificationTitleChanged)
     Q_PROPERTY(QString notificationLowText READ getNotificationLowText WRITE setNotificationLowText NOTIFY notificationLowTextChanged)
     Q_PROPERTY(QString notificationHighText READ getNotificationHighText WRITE setNotificationHighText NOTIFY notificationHighTextChanged)
+    Q_PROPERTY(QString notificationHealthText READ getNotificationHealthText WRITE setNotificationHealthText NOTIFY notificationHealthTextChanged)
     Q_PROPERTY(QString logFilename READ getLogFilename NOTIFY logFilenameChanged)
     Q_PROPERTY(int logLevel READ getLogLevel WRITE setLogLevel NOTIFY logLevelChanged)
 
@@ -46,29 +50,36 @@ public:
 
     int  getLowAlert();
     int  getHighAlert();
+    int  getHealthAlert();
     int  getHighNotificationsInterval();
     int  getLowNotificationsInterval();
+    int  getHealthNotificationsInterval();
     int  getLowLimit();
     int  getHighLimit();
     bool getLimitEnabled();
     QString getLowAlertFile();
     QString getHighAlertFile();
+    QString getHealthAlertFile();
     QString getNotificationTitle();
     QString getNotificationLowText();
     QString getNotificationHighText();
+    QString getNotificationHealthText();
     QString getLogFilename();
     int getLogLevel();
 
     void setLowAlert(const int newLimit);
     void setHighAlert(const int newLimit);
+    void setHealthAlert(const int newLimit);
     void setHighNotificationsInterval(const int newInterval);
     void setLowNotificationsInterval(const int newInterval);
+    void setHealthNotificationsInterval(const int newInterval);
     void setLowLimit(const int newLimit);
     void setHighLimit(const int newLimit);
     void setLimitEnabled(const bool newEnabled);
     void setNotificationTitle(const QString newText);
     void setNotificationLowText(const QString newText);
     void setNotificationHighText(const QString newText);
+    void setNotificationHealthText(const QString newText);
     void setLogLevel(const int newLogLevel);
 
 private:
@@ -79,32 +90,40 @@ private:
     // Default values
     int lowAlert = 25;
     int highAlert = 75;
+    int healthAlert = 1; // warn
     int highNotificationsInterval = 60;
     int lowNotificationsInterval = 60;
+    int healthNotificationsInterval = 60;
     int limitEnabled = 1; // Converted to boolean for QML
     int lowLimit = 65;
     int highLimit = 70;
     QString lowAlertFile = "/usr/share/sounds/jolla-ambient/stereo/general_warning.wav";
     QString highAlertFile = "/usr/share/sounds/jolla-ambient/stereo/positive_confirmation.wav";
+    QString healthAlertFile = lowAlertFile;
     QString notificationTitle;
     QString notificationLowText;
     QString notificationHighText;
+    QString notificationHealthText;
     QString logFilename;
     int logLevel;
 
     // To avoid repeating the same string over and over and over...
     const char* sLowAlert = "lowAlert";
     const char* sHighAlert = "highAlert";
+    const char* sHealthAlert = "healthAlert";
     const char* sHighNotificationsInterval = "highNotificationsInterval";
     const char* sLowNotificationsInterval = "lowNotificationsInterval";
+    const char* sHealthNotificationsInterval = "healthNotificationsInterval";
     const char* sLimitEnabled = "limitEnabled";
     const char* sLowLimit = "lowLimit";
     const char* sHighLimit = "highLimit";
     const char* sLowAlertFile = "lowAlertFile";
     const char* sHighAlertFile = "highAlertFile";
+    const char* sHealthAlertFile = "healthAlertFile";
     const char* sNotificationTitle = "notificationTitle";
     const char* sNotificationLowText = "notificationLowText";
     const char* sNotificationHighText = "notificationHighText";
+    const char* sNotificationHealthText = "notificationHealthText";
     const char* sLogFilename = "logFilename";
     const char* sLogLevel = "logLevel";
 
@@ -117,16 +136,20 @@ private:
 signals:
     void lowAlertChanged(int);
     void highAlertChanged(int);
+    void healthAlertChanged(int);
     void highNotificationsIntervalChanged(int);
     void lowNotificationsIntervalChanged(int);
+    void healthNotificationsIntervalChanged(int);
     void limitEnabledChanged(bool);
     void lowLimitChanged(int);
     void highLimitChanged(int);
     void lowAlertFileChanged(QString);
     void highAlertFileChanged(QString);
+    void healthAlertFileChanged(QString);
     void notificationTitleChanged(QString);
     void notificationLowTextChanged(QString);
     void notificationHighTextChanged(QString);
+    void notificationHealthTextChanged(QString);
     void logFilenameChanged(QString);
     void logLevelChanged(int);
 };

--- a/application/src/settings.h
+++ b/application/src/settings.h
@@ -40,7 +40,9 @@ class Settings : public QObject
     Q_PROPERTY(QString notificationTitle READ getNotificationTitle WRITE setNotificationTitle NOTIFY notificationTitleChanged)
     Q_PROPERTY(QString notificationLowText READ getNotificationLowText WRITE setNotificationLowText NOTIFY notificationLowTextChanged)
     Q_PROPERTY(QString notificationHighText READ getNotificationHighText WRITE setNotificationHighText NOTIFY notificationHighTextChanged)
-    Q_PROPERTY(QString notificationHealthText READ getNotificationHealthText WRITE setNotificationHealthText NOTIFY notificationHealthTextChanged)
+    Q_PROPERTY(QString notificationHealthTitle READ getNotificationHealthTitle WRITE setNotificationHealthTitle NOTIFY notificationHealthTitleChanged)
+    Q_PROPERTY(QString notificationHealthWarnText READ getNotificationHealthWarnText WRITE setNotificationHealthWarnText NOTIFY notificationHealthWarnTextChanged)
+    Q_PROPERTY(QString notificationHealthCritText READ getNotificationHealthCritText WRITE setNotificationHealthCritText NOTIFY notificationHealthCritTextChanged)
     Q_PROPERTY(QString logFilename READ getLogFilename NOTIFY logFilenameChanged)
     Q_PROPERTY(int logLevel READ getLogLevel WRITE setLogLevel NOTIFY logLevelChanged)
 
@@ -63,7 +65,9 @@ public:
     QString getNotificationTitle();
     QString getNotificationLowText();
     QString getNotificationHighText();
-    QString getNotificationHealthText();
+    QString getNotificationHealthTitle();
+    QString getNotificationHealthWarnText();
+    QString getNotificationHealthCritText();
     QString getLogFilename();
     int getLogLevel();
 
@@ -79,7 +83,9 @@ public:
     void setNotificationTitle(const QString newText);
     void setNotificationLowText(const QString newText);
     void setNotificationHighText(const QString newText);
-    void setNotificationHealthText(const QString newText);
+    void setNotificationHealthTitle(const QString newText);
+    void setNotificationHealthWarnText(const QString newText);
+    void setNotificationHealthCritText(const QString newText);
     void setLogLevel(const int newLogLevel);
 
 private:
@@ -103,7 +109,9 @@ private:
     QString notificationTitle;
     QString notificationLowText;
     QString notificationHighText;
-    QString notificationHealthText;
+    QString notificationHealthTitle;
+    QString notificationHealthWarnText;
+    QString notificationHealthCritText;
     QString logFilename;
     int logLevel;
 
@@ -123,7 +131,9 @@ private:
     const char* sNotificationTitle = "notificationTitle";
     const char* sNotificationLowText = "notificationLowText";
     const char* sNotificationHighText = "notificationHighText";
-    const char* sNotificationHealthText = "notificationHealthText";
+    const char* sNotificationHealthTitle = "notificationHealthTitle";
+    const char* sNotificationHealthWarnText = "notificationHealthWarnText";
+    const char* sNotificationHealthCritText = "notificationHealthCritText";
     const char* sLogFilename = "logFilename";
     const char* sLogLevel = "logLevel";
 
@@ -149,7 +159,9 @@ signals:
     void notificationTitleChanged(QString);
     void notificationLowTextChanged(QString);
     void notificationHighTextChanged(QString);
-    void notificationHealthTextChanged(QString);
+    void notificationHealthTitleChanged(QString);
+    void notificationHealthWarnTextChanged(QString);
+    void notificationHealthCritTextChanged(QString);
     void logFilenameChanged(QString);
     void logLevelChanged(int);
 };

--- a/application/translations/harbour-batterybuddy-de_DE.ts
+++ b/application/translations/harbour-batterybuddy-de_DE.ts
@@ -395,19 +395,19 @@
     </message>
     <message>
         <source>Display visual and audible notifications about battery health, when the battery temperature is below or above safe values.</source>
-        <translation>Visuelle und akustische Benachrichtigungen zum Batteriezustand anzeigen, sobald die Temperatur über gewissen Schwellwerten liegt.</translation>
+        <translation type="vanished">Visuelle und akustische Benachrichtigungen zum Batteriezustand anzeigen, sobald die Temperatur über gewissen Schwellwerten liegt.</translation>
     </message>
     <message>
         <source>Battery health notification</source>
-        <translation>Zustandsbenachrichtigung</translation>
+        <translation type="vanished">Zustandsbenachrichtigung</translation>
     </message>
     <message>
         <source>Warn on Health status:</source>
-        <translation>Benachrichtigung bei Zustand:</translation>
+        <translation type="vanished">Benachrichtigung bei Zustand:</translation>
     </message>
     <message>
         <source>None</source>
-        <translation>Keine</translation>
+        <translation type="vanished">Keine</translation>
     </message>
     <message>
         <source>Warning</source>
@@ -419,6 +419,22 @@
     </message>
     <message>
         <source>Battery health warning interval</source>
+        <translation type="vanished">Zustandsbenachrichtigungsintervall</translation>
+    </message>
+    <message>
+        <source>Display visual and audible notifications about battery health, when the battery status exceeds safe values.&lt;br /&gt;This usually means high temperature but can be affected by other factors depending on the hardware.</source>
+        <translation>Visuelle und akustische Benachrichtigungen zum Batteriezustand anzeigen, sobald gewisse Schwellwerte erreicht werden.&lt;br /&gt;Das betrifft meist die Temperatur, kann aber je nach Hardware auch andere Faktoren beinhalten.</translation>
+    </message>
+    <message>
+        <source>Health notification</source>
+        <translation>Zustandsbenachrichtigung</translation>
+    </message>
+    <message>
+        <source>Notify on Health status:</source>
+        <translation>Benachrichtigung zum Zustand:</translation>
+    </message>
+    <message>
+        <source>Health notification interval</source>
         <translation>Zustandsbenachrichtigungsintervall</translation>
     </message>
 </context>

--- a/application/translations/harbour-batterybuddy-de_DE.ts
+++ b/application/translations/harbour-batterybuddy-de_DE.ts
@@ -156,34 +156,34 @@
     <name>LogPage</name>
     <message>
         <source>View log</source>
-        <translation type="unfinished"></translation>
+        <translation>Logdatei ansehen</translation>
     </message>
     <message>
         <source>Update</source>
-        <translation type="unfinished"></translation>
+        <translation>Aktualisieren</translation>
     </message>
     <message>
         <source>Copy</source>
-        <translation type="unfinished"></translation>
+        <translation>Kopieren</translation>
     </message>
     <message>
         <source>Log level</source>
-        <translation type="unfinished"></translation>
+        <translation>Log Level</translation>
     </message>
     <message>
         <source>Quiet</source>
         <comment>Low log setting</comment>
-        <translation type="unfinished"></translation>
+        <translation>Still</translation>
     </message>
     <message>
         <source>Verbose</source>
         <comment>Medium log setting</comment>
-        <translation type="unfinished"></translation>
+        <translation>Mittel</translation>
     </message>
     <message>
         <source>Debug</source>
         <comment>High log setting</comment>
-        <translation type="unfinished"></translation>
+        <translation>Debug</translation>
     </message>
 </context>
 <context>
@@ -275,20 +275,43 @@
         <source>Current:</source>
         <translation>Strom:</translation>
     </message>
+    <message>
+        <source>Good</source>
+        <comment>Battery is OK</comment>
+        <translation>die Batterie ist OK</translation>
+    </message>
+    <message>
+        <source>Warm</source>
+        <comment>Battery is warm</comment>
+        <translation>die Batterie ist warm</translation>
+    </message>
+    <message>
+        <source>Overheated</source>
+        <comment>Battery is very hot</comment>
+        <translation>die Batterie ist sehr heiss</translation>
+    </message>
+    <message>
+        <source>Health:</source>
+        <translation>Zustand:</translation>
+    </message>
+    <message>
+        <source>Temperature:</source>
+        <translation>Temperatur:</translation>
+    </message>
 </context>
 <context>
     <name>Settings</name>
     <message>
         <source>Battery charge %1%</source>
-        <translation>Akkustand %1%</translation>
+        <translation type="vanished">Akkustand %1%</translation>
     </message>
     <message>
         <source>Please connect the charger.</source>
-        <translation>Bitte Ladegerät anschließen.</translation>
+        <translation type="vanished">Bitte Ladegerät anschließen.</translation>
     </message>
     <message>
         <source>Please disconnect the charger.</source>
-        <translation>Bitte Ladegerät trennen.</translation>
+        <translation type="vanished">Bitte Ladegerät trennen.</translation>
     </message>
 </context>
 <context>
@@ -364,7 +387,39 @@
     </message>
     <message>
         <source>View log</source>
-        <translation type="unfinished"></translation>
+        <translation>Logdatei ansehen</translation>
+    </message>
+    <message>
+        <source>Health Notification settings</source>
+        <translation>Einstellungen zur Zustandbenachrichtigung</translation>
+    </message>
+    <message>
+        <source>Display visual and audible notifications about battery health, when the battery temperature is below or above safe values.</source>
+        <translation>Visuelle und akustische Benachrichtigungen zum Batteriezustand anzeigen, sobald die Temperatur über gewissen Schwellwerten liegt.</translation>
+    </message>
+    <message>
+        <source>Battery health notification</source>
+        <translation>Zustandsbenachrichtigung</translation>
+    </message>
+    <message>
+        <source>Warn on Health status:</source>
+        <translation>Benachrichtigung bei Zustand:</translation>
+    </message>
+    <message>
+        <source>None</source>
+        <translation>Keine</translation>
+    </message>
+    <message>
+        <source>Warning</source>
+        <translation>Warnung</translation>
+    </message>
+    <message>
+        <source>Critical</source>
+        <translation>Kritisch</translation>
+    </message>
+    <message>
+        <source>Battery health warning interval</source>
+        <translation>Zustandsbenachrichtigungsintervall</translation>
     </message>
 </context>
 </TS>


### PR DESCRIPTION
First version.

Should be enough for now to do the daemon handling.

Areas for improvement:

 - Should we split up health and temperature handling? Would allow to set temp low/high warnings similar to charge value. OTOH, built-in limits via health are probably better than user-chosen ones.
 - Health states: reading through some of the Linux source code there are states like Cold, Overvoltage, and others. Not all related to temperature, and non-standardized across drivers
 - better tieing of the combobox selector and internal int values of the settings. Maybe use and export an Q_ENUM.
