### PR TITLE
[PineTab] add device file paths

### DIFF
--- a/application/qml/pages/MainPage.qml
+++ b/application/qml/pages/MainPage.qml
@@ -137,7 +137,7 @@ Page {
                             if      ( battery.chargerConnected && !battery.acConnected) { return qsTr("USB") }
                             else if (!battery.chargerConnected &&  battery.acConnected) { return qsTr("AC") }
                             else if ( battery.chargerConnected &&  battery.acConnected) { return qsTr("USB") + "/" + qsTr("AC") }
-                            return "unknown power source"
+                            return qsTr("unknown", "Charger not detected, or faulty, or something")
                         }
                         label: qsTr("Charger connected:")
                         value: connected ? (qsTr("yes") + " (" + chargerType + ")") : qsTr("no")

--- a/application/service/restore-write-permissions.sh
+++ b/application/service/restore-write-permissions.sh
@@ -21,4 +21,5 @@ chmod 644 /sys/class/power_supply/battery/charging_enabled 2>/dev/null
 chmod 644 /sys/class/power_supply/battery/constant_charge_current_max 2>/dev/null
 chmod 644 /sys/class/power_supply/usb/charger_disable 2>/dev/null
 chmod 644 /sys/class/power_supply/dollar_cove_battery/enable_charging 2>/dev/null
+chmod 644 /sys/class/power_supply/axp-20x-battery/constant_charge_current_max 2>/dev/null
 exit 0

--- a/application/service/set-write-permissions.sh
+++ b/application/service/set-write-permissions.sh
@@ -21,4 +21,5 @@ chmod 666 /sys/class/power_supply/battery/charging_enabled 2>/dev/null
 chmod 666 /sys/class/power_supply/battery/constant_charge_current_max 2>/dev/null
 chmod 666 /sys/class/power_supply/usb/charger_disable 2>/dev/null
 chmod 666 /sys/class/power_supply/dollar_cove_battery/enable_charging 2>/dev/null
+chmod 666 /sys/class/power_supply/axp-20x-battery/constant_charge_current_max 2>/dev/null
 exit 0

--- a/application/src/battery.cpp
+++ b/application/src/battery.cpp
@@ -90,7 +90,7 @@ Battery::Battery(Settings* newSettings, Logger* newLogger, QObject* parent) : QO
     // Number: 0 or 1
     const QStringList acPresentFiles = {
         "/sys/class/power_supply/ac/present",
-        "/sys/class/power_supply/axp20x-ac/present"
+        "/sys/class/power_supply/axp813-ac/present"
     };
 
     foreach(const QString& file, acPresentFiles) {

--- a/application/src/battery.cpp
+++ b/application/src/battery.cpp
@@ -27,7 +27,8 @@ Battery::Battery(Settings* newSettings, Logger* newLogger, QObject* parent) : QO
 
     // Battery charge percentage, number, e.g. 42
     filenames << "/sys/class/power_supply/battery/capacity"
-              << "/sys/class/power_supply/dollar_cove_battery/capacity";
+              << "/sys/class/power_supply/dollar_cove_battery/capacity"
+              << "/sys/class/power_supply/axp20x-battery/capacity";
     foreach(const QString& file, filenames) {
         if(!chargeFile && QFile::exists(file)) {
             chargeFile = new QFile(file, this);
@@ -40,7 +41,8 @@ Battery::Battery(Settings* newSettings, Logger* newLogger, QObject* parent) : QO
     // Number: battery/charging current, e.g. -1450000 (-145mA)
     filenames.clear();
     filenames << "/sys/class/power_supply/battery/current_now"
-              << "/sys/class/power_supply/dollar_cove_battery/current_now";
+              << "/sys/class/power_supply/dollar_cove_battery/current_now"
+              << "/sys/class/power_supply/axp20x-battery/current_now";
 
     foreach(const QString& file, filenames) {
         if(!currentFile && QFile::exists(file)) {
@@ -54,7 +56,8 @@ Battery::Battery(Settings* newSettings, Logger* newLogger, QObject* parent) : QO
     // String: charging, discharging, full, empty, unknown (others?)
     filenames.clear();
     filenames << "/sys/class/power_supply/battery/status"
-              << "/sys/class/power_supply/dollar_cove_battery/status";
+              << "/sys/class/power_supply/dollar_cove_battery/status"
+              << "/sys/class/power_supply/axp20x-battery/status";
 
     foreach(const QString& file, filenames) {
         if(!stateFile && QFile::exists(file)) {
@@ -68,7 +71,8 @@ Battery::Battery(Settings* newSettings, Logger* newLogger, QObject* parent) : QO
     // Number: 0 or 1
     filenames.clear();
     filenames << "/sys/class/power_supply/usb/present"
-              << "/sys/class/power_supply/dollar_cove_charger/present";
+              << "/sys/class/power_supply/dollar_cove_charger/present"
+              << "/sys/class/power_supply/axp20x-usb/present";
 
     foreach(const QString& file, filenames) {
         if(!chargerConnectedFile && QFile::exists(file)) {
@@ -96,7 +100,8 @@ Battery::Battery(Settings* newSettings, Logger* newLogger, QObject* parent) : QO
     // String: health state
     filenames.clear();
     filenames << "/sys/class/power_supply/battery/health"
-              << "/sys/class/power_supply/dollar_cove_battery/health";
+              << "/sys/class/power_supply/dollar_cove_battery/health"
+              << "/sys/class/power_supply/axp20x-battery/health";
     foreach(const QString& file, filenames) {
         if(!healthFile && QFile::exists(file)) {
             healthFile = new QFile(file, this);

--- a/application/src/battery.cpp
+++ b/application/src/battery.cpp
@@ -211,8 +211,14 @@ void Battery::updateData()
         healthFile->close();
     }
 
+    // e.g. PineTab outputs an integer in centi-centigrade
+    // Note that the formatter in the QML page, and the logger divide by 10 again!
+    float tempCorrectionFactor = 1.0 ;
+    if(temperatureFile->fileName().contains(QStringLiteral("xp20x-battery"))) {
+        tempCorrectionFactor = 10.0 ;
+    }
     if(temperatureFile && temperatureFile->open(QIODevice::ReadOnly)) {
-        nextTemperature = temperatureFile->readLine().trimmed().toInt();
+        nextTemperature = temperatureFile->readLine().trimmed().toInt() / tempCorrectionFactor;
         if(nextTemperature != temperature) {
             temperature = nextTemperature;
             emit temperatureChanged(temperature);

--- a/application/src/battery.cpp
+++ b/application/src/battery.cpp
@@ -72,7 +72,8 @@ Battery::Battery(Settings* newSettings, Logger* newLogger, QObject* parent) : QO
     filenames.clear();
     filenames << "/sys/class/power_supply/usb/present"
               << "/sys/class/power_supply/dollar_cove_charger/present"
-              << "/sys/class/power_supply/axp20x-usb/present";
+              << "/sys/class/power_supply/axp20x-usb/present"
+              << "/sys/class/power_supply/axp20x-ac/present";
 
     foreach(const QString& file, filenames) {
         if(!chargerConnectedFile && QFile::exists(file)) {

--- a/application/src/battery.cpp
+++ b/application/src/battery.cpp
@@ -75,8 +75,7 @@ Battery::Battery(Settings* newSettings, Logger* newLogger, QObject* parent) : QO
     const QStringList usbPresentFiles = {
         "/sys/class/power_supply/usb/present",
         "/sys/class/power_supply/dollar_cove_charger/present",
-        "/sys/class/power_supply/axp20x-usb/present",
-        "/sys/class/power_supply/axp20x-ac/present"
+        "/sys/class/power_supply/axp20x-usb/present"
     };
 
     foreach(const QString& file, usbPresentFiles) {
@@ -90,7 +89,8 @@ Battery::Battery(Settings* newSettings, Logger* newLogger, QObject* parent) : QO
 
     // Number: 0 or 1
     const QStringList acPresentFiles = {
-        "/sys/class/power_supply/ac/present"
+        "/sys/class/power_supply/ac/present",
+        "/sys/class/power_supply/axp20x-ac/present"
     };
 
     foreach(const QString& file, acPresentFiles) {

--- a/application/src/battery.cpp
+++ b/application/src/battery.cpp
@@ -115,6 +115,11 @@ Battery::Battery(Settings* newSettings, Logger* newLogger, QObject* parent) : QO
             break;
         }
     }
+    // e.g. PineTab outputs an integer in centi-centigrade
+    // Note that the formatter in the QML page, and the logger divide by 10 again!
+    if(temperatureFile->fileName().contains(QStringLiteral("xp20x-battery"))) {
+        tempCorrectionFactor = 10.0;
+    }
 
     logL("Battery temperature file: " + (temperatureFile ? temperatureFile->fileName() : notFound));
 
@@ -243,12 +248,6 @@ void Battery::updateData()
         healthFile->close();
     }
 
-    // e.g. PineTab outputs an integer in centi-centigrade
-    // Note that the formatter in the QML page, and the logger divide by 10 again!
-    float tempCorrectionFactor = 1.0 ;
-    if(temperatureFile->fileName().contains(QStringLiteral("xp20x-battery"))) {
-        tempCorrectionFactor = 10.0 ;
-    }
     if(temperatureFile && temperatureFile->open(QIODevice::ReadOnly)) {
         nextTemperature = temperatureFile->readLine().trimmed().toInt() / tempCorrectionFactor;
         if(nextTemperature != temperature) {

--- a/application/src/battery.cpp
+++ b/application/src/battery.cpp
@@ -87,7 +87,8 @@ Battery::Battery(Settings* newSettings, Logger* newLogger, QObject* parent) : QO
     // Number: temperature
     filenames.clear();
     filenames << "/sys/class/power_supply/battery/temp"
-              << "/sys/class/power_supply/dollar_cove_battery/temp";
+              << "/sys/class/power_supply/dollar_cove_battery/temp"
+              << "/sys/class/power_supply/axp20x-battery/hwmon0/in0_input";
 
     foreach(const QString& file, filenames) {
         if(!temperatureFile && QFile::exists(file)) {

--- a/application/src/battery.h
+++ b/application/src/battery.h
@@ -85,6 +85,7 @@ private:
 
     QString health = "unknown"; // Good, warm, overheat. Might have Cold or Overvoltage depending on driver
     int temperature = 0x7FFFFFFF; // This value means "unknown" (32-bit INT_MAX)
+    float tempCorrectionFactor = 1.0; // PineTab outputs an integer in centi-centigrade
 
     int enableChargingValue = 1;
     int disableChargingValue = 0;
@@ -98,7 +99,6 @@ private:
     bool nextAcConnected = acConnected;
     QString nextState = state;
     bool nextChargingEnabled = chargingEnabled;
-
 
     QString  nextHealth = health;
     int nextTemperature = temperature;

--- a/service/src/battery.cpp
+++ b/service/src/battery.cpp
@@ -69,6 +69,7 @@ Battery::Battery(Logger* newLogger, bool loglevelSet, QCoreApplication *app, QOb
     // Maximum charge current in microamps, e.g. 3500000 (3500mA)
     const QStringList maxCurrentFiles = {
         "/sys/class/power_supply/battery/constant_charge_current_max"
+        "/sys/class/power_supply/axp20x-battery/constant_charge_current_max"
     };
 
     foreach(const QString& file, maxCurrentFiles) {

--- a/service/src/battery.cpp
+++ b/service/src/battery.cpp
@@ -293,15 +293,16 @@ void Battery::updateData()
     }
 
     // e.g. PineTab outputs an integer in centi-centigrade
-    float tempCorrectionFactor = 10 ;
-    if(temperatureFile.fileName().contains(QStringLiteral("xp20x-battery"))) {
-        float tempCorrectionFactor = 100 ;
+    // Note that the formatter in the QML page, and the logger divide by 10 again!
+    float tempCorrectionFactor = 1.0 ;
+    if(temperatureFile->fileName().contains(QStringLiteral("xp20x-battery"))) {
+        tempCorrectionFactor = 10.0 ;
     }
     if(temperatureFile && temperatureFile->open(QIODevice::ReadOnly)) {
-        nextTemperature = temperatureFile->readLine().trimmed().toInt();
+        nextTemperature = temperatureFile->readLine().trimmed().toInt() / tempCorrectionFactor;
         if(nextTemperature != temperature) {
-            if((nextTemperature / tempCorrectionFactor ) != (temperature / tempCorrectionFactor )) {
-                logM(QString("Temperature: %1°C").arg(nextTemperature / tempCorrectionFactor ));
+            if((nextTemperature / 10 ) != (temperature / 10 )) {
+                logM(QString("Temperature: %1°C").arg(nextTemperature / 10 ));
             }
             temperature = nextTemperature;
         }

--- a/service/src/battery.cpp
+++ b/service/src/battery.cpp
@@ -168,6 +168,12 @@ Battery::Battery(Logger* newLogger, bool loglevelSet, QCoreApplication *app, QOb
         }
     }
 
+    // e.g. PineTab outputs an integer in centi-centigrade
+    // Note that the formatter in the QML page, and the logger divide by 10 again!
+    if(temperatureFile->fileName().contains(QStringLiteral("xp20x-battery"))) {
+        tempCorrectionFactor = 10.0;
+    }
+
     logL("Battery temperature file: " + (temperatureFile ? temperatureFile->fileName() : notFound));
 
     // String: health state
@@ -323,12 +329,6 @@ void Battery::updateData()
         stateFile->close();
     }
 
-    // e.g. PineTab outputs an integer in centi-centigrade
-    // Note that the formatter in the QML page, and the logger divide by 10 again!
-    float tempCorrectionFactor = 1.0 ;
-    if(temperatureFile->fileName().contains(QStringLiteral("xp20x-battery"))) {
-        tempCorrectionFactor = 10.0 ;
-    }
     if(temperatureFile && temperatureFile->open(QIODevice::ReadOnly)) {
         nextTemperature = temperatureFile->readLine().trimmed().toInt() / tempCorrectionFactor;
         if(nextTemperature != temperature) {

--- a/service/src/battery.cpp
+++ b/service/src/battery.cpp
@@ -142,7 +142,7 @@ Battery::Battery(Logger* newLogger, bool loglevelSet, QCoreApplication *app, QOb
     // Charger connected, bool (number): 0 or 1
     const QStringList acFiles = {
         "/sys/class/power_supply/ac/present",
-        "/sys/class/power_supply/axp20x-ac/present"
+        "/sys/class/power_supply/axp813-ac/present"
     };
 
     foreach(const QString& file, acFiles) {

--- a/service/src/battery.cpp
+++ b/service/src/battery.cpp
@@ -127,8 +127,7 @@ Battery::Battery(Logger* newLogger, bool loglevelSet, QCoreApplication *app, QOb
     const QStringList chargerFiles = {
         "/sys/class/power_supply/usb/present",
         "/sys/class/power_supply/dollar_cove_charger/present",
-        "/sys/class/power_supply/axp20x-usb/present",
-        "/sys/class/power_supply/axp20x-ac/present"
+        "/sys/class/power_supply/axp20x-usb/present"
     };
 
     foreach(const QString& file, chargerFiles) {
@@ -142,7 +141,8 @@ Battery::Battery(Logger* newLogger, bool loglevelSet, QCoreApplication *app, QOb
 
     // Charger connected, bool (number): 0 or 1
     const QStringList acFiles = {
-        "/sys/class/power_supply/ac/present"
+        "/sys/class/power_supply/ac/present",
+        "/sys/class/power_supply/axp20x-ac/present"
     };
 
     foreach(const QString& file, acFiles) {

--- a/service/src/battery.cpp
+++ b/service/src/battery.cpp
@@ -332,8 +332,8 @@ void Battery::updateData()
     if(temperatureFile && temperatureFile->open(QIODevice::ReadOnly)) {
         nextTemperature = temperatureFile->readLine().trimmed().toInt() / tempCorrectionFactor;
         if(nextTemperature != temperature) {
-            if((nextTemperature / 10 ) != (temperature / 10 )) {
-                logM(QString("Temperature: %1°C").arg(nextTemperature / 10 ));
+            if((nextTemperature / 10) != (temperature / 10)) {
+                logM(QString("Temperature: %1°C").arg(nextTemperature / 10));
             }
             temperature = nextTemperature;
         }

--- a/service/src/battery.h
+++ b/service/src/battery.h
@@ -121,6 +121,7 @@ private:
     QString nextState = state;
     bool nextChargingEnabled = chargingEnabled;
     int nextTemperature = temperature;
+    float tempCorrectionFactor = 1.0;
     QString nextHealth = health;
 
     QFileDevice::Permissions originalPerms; // Updated in constructor


### PR DESCRIPTION
This adds support for the PineTab port.

This device seems to lack charge control capability AFAICS, but the readouts work fine.